### PR TITLE
Fix link to vundle in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ The default mapping `ih`for an inner hunk. See the included documentation on how
 
 Installation
 ------------
-I recommend installing it via vundle (https://github.com/gmarik/vundle):
+I recommend installing it via vundle ([https://github.com/gmarik/vundle](https://github.com/gmarik/vundle)):
 
     Bundle 'gilligan/textobj-gitgutter'


### PR DESCRIPTION
Github's autolinking was making the ): after the URL part of the URL.
