### PR TITLE
GH-5: GitGutter() function not found during `vih`

### DIFF
--- a/autoload/textobj/gitgutter.vim
+++ b/autoload/textobj/gitgutter.vim
@@ -1,5 +1,5 @@
 function! textobj#gitgutter#select_i()
-  call GitGutter(expand('%:p'))
+  GitGutter
   if !s:line_has_sign()
       return 0
   endif


### PR DESCRIPTION
The GitGutter plugin's API has changed.  It has replaced the GitGutter() 
function with a :GitGutter command that updates signs in current buffer. As a
result, I get the following error when typing `vih` in normal mode:

```
    Error detected while processing function
98..<SNR>140_select_function_wrapper..textobj#gitgutter#select_i:
   line    1:
   E117: Unknown function: GitGutter
   Press ENTER or type command to continue
```

This patch updates our use of GitGutter() to :GitGutter to fix the bug.
